### PR TITLE
Custom Blocks - permission updates

### DIFF
--- a/code/blocks/AccordionBlock.php
+++ b/code/blocks/AccordionBlock.php
@@ -55,4 +55,42 @@ class AccordionBlock extends Block
 
         return $fields;
     }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/CallToActionBlock.php
+++ b/code/blocks/CallToActionBlock.php
@@ -11,4 +11,42 @@ class CallToActionBlock extends Block
      * @var string
      */
     private static $plural_name = 'Call To Action Blocks';
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/ChildListBlock.php
+++ b/code/blocks/ChildListBlock.php
@@ -11,4 +11,42 @@ class ChildListBlock extends Block
      * @var string
      */
     private static $plural_name = 'Child List Blocks';
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/EmailSignupBlock.php
+++ b/code/blocks/EmailSignupBlock.php
@@ -11,4 +11,42 @@ class EmailSignupBlock extends Block
      * @var string
      */
     private static $plural_name = 'Email Signup Blocks';
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/FormBlock.php
+++ b/code/blocks/FormBlock.php
@@ -71,6 +71,13 @@ class FormBlock extends Block
         if (!class_exists('UserDefinedForm')) {
             return false;
         }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
         return parent::canCreate();
     }
 
@@ -83,6 +90,13 @@ class FormBlock extends Block
         if (!class_exists('UserDefinedForm')) {
             return false;
         }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
         return parent::canView();
     }
 }

--- a/code/blocks/ImageBlock.php
+++ b/code/blocks/ImageBlock.php
@@ -37,4 +37,42 @@ class ImageBlock extends Block
 
         return $fields;
     }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/PromoBlock.php
+++ b/code/blocks/PromoBlock.php
@@ -68,4 +68,42 @@ class PromoBlock extends Block
     {
         return $this->Promos()->sort('SortOrder');
     }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }

--- a/code/blocks/RecentBlogPostsBlock.php
+++ b/code/blocks/RecentBlogPostsBlock.php
@@ -71,6 +71,13 @@ class RecentBlogPostsBlock extends Block
         if (!class_exists('Blog')) {
             return false;
         }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
         return parent::canCreate();
     }
 
@@ -83,6 +90,13 @@ class RecentBlogPostsBlock extends Block
         if (!class_exists('Blog')) {
             return false;
         }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
         return parent::canView();
     }
 }

--- a/code/blocks/SlideshowBlock.php
+++ b/code/blocks/SlideshowBlock.php
@@ -11,4 +11,42 @@ class SlideshowBlock extends Block
      * @var string
      */
     private static $plural_name = 'Slideshow Blocks';
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canCreate($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canCreate', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canCreate($member);
+    }
+
+    /**
+     * @param null $member
+     * @return bool|null
+     */
+    public function canView($member = null)
+    {
+        if (!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+            $member = Member::currentUserID();
+        }
+
+        // Standard mechanism for accepting permission changes from extensions
+        $extended = $this->extendedCan('canView', $member);
+        if ($extended !== null) {
+            return $extended;
+        }
+
+        return parent::canView($member);
+    }
 }


### PR DESCRIPTION
Allows `canCreate` and `canView` to be overridden via DataExtensions