### PR TITLE
Section navigation now shows parent's children

### DIFF
--- a/code/blocks/SectionNavigationBlock.php
+++ b/code/blocks/SectionNavigationBlock.php
@@ -22,7 +22,13 @@ class SectionNavigationBlock extends Block
     public function getSectionNavigation()
     {
         if ($page = $this->getCurrentPage()) {
-            return $page->Children() ? $page->Children() : $page->Parent()->Children();
+            if ($page->Children()->Count() > 0) {
+                return $page->Children();
+            } else if ($page->Parent()) {
+                return $page->Parent()->Children();
+            } else {
+                return false;
+            }
         }
 
         return false;


### PR DESCRIPTION
if page doesn't have children
  - added check for parent (in case this gets added on a page without children or a parent)