### PR TITLE
composer requirements - groupable-gridfield to ^0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "sheadawson/silverstripe-blocks": "^1.0",
     "sheadawson/quickaddnew": "^1.1",
     "sheadawson/silverstripe-linkable": "^1.3",
-    "micschk/silverstripe-groupable-gridfield": "^0.4",
+    "micschk/silverstripe-groupable-gridfield": "^0.5",
     "heyday/silverstripe-versioneddataobjects": "^2.0",
     "symbiote/silverstripe-gridfieldextensions": "^1.4",
     "symbiote/silverstripe-addressable": "^1.1"


### PR DESCRIPTION
fixes issue with newer versions of blocks, gridfieldorderablerows